### PR TITLE
feat: add edit argument in action menu

### DIFF
--- a/language/.en.json
+++ b/language/.en.json
@@ -112,6 +112,10 @@
           "default": "Delete argument"
         },
         {
+          "label": "Label used to show the edit action",
+          "default": "Edit argument"
+        },
+        {
           "label": "Text inside the arguments drop zone",
           "default": "Drop arguments here"
         }

--- a/language/.en.json
+++ b/language/.en.json
@@ -116,6 +116,10 @@
           "default": "Edit argument"
         },
         {
+          "label": "Label for the argument",
+          "default": "Argument"
+        },
+        {
           "label": "Text inside the arguments drop zone",
           "default": "Drop arguments here"
         }

--- a/language/ar.json
+++ b/language/ar.json
@@ -112,6 +112,10 @@
           "default": "حذف الحجة"
         },
         {
+          "label": "Label used to show the edit action",
+          "default": "Edit argument"
+        },
+        {
           "label": "نص داخل منطقة إفلات الحجج عند يكون خيار إضافة حجج جديدة معطلاً",
           "default": "إفلات الحجج هنا"
         }

--- a/language/ar.json
+++ b/language/ar.json
@@ -116,6 +116,10 @@
           "default": "Edit argument"
         },
         {
+          "label": "Label for the argument",
+          "default": "Argument"
+        },
+        {
           "label": "نص داخل منطقة إفلات الحجج عند يكون خيار إضافة حجج جديدة معطلاً",
           "default": "إفلات الحجج هنا"
         }

--- a/language/es-MX.json
+++ b/language/es-MX.json
@@ -116,6 +116,10 @@
           "default": "Edit argument"
         },
         {
+          "label": "Label for the argument",
+          "default": "Argument"
+        },
+        {
           "label": "Texto adentro de la zona de caída de los argumentos cuando está deshabilitado el añadir nuevos argumentos",
           "default": "Dejar caer argumentos aquí"
         }

--- a/language/es-MX.json
+++ b/language/es-MX.json
@@ -112,6 +112,10 @@
           "default": "Eliminar argumento"
         },
         {
+          "label": "Label used to show the edit action",
+          "default": "Edit argument"
+        },
+        {
           "label": "Texto adentro de la zona de caída de los argumentos cuando está deshabilitado el añadir nuevos argumentos",
           "default": "Dejar caer argumentos aquí"
         }

--- a/language/es.json
+++ b/language/es.json
@@ -116,6 +116,10 @@
           "default": "Edit argument"
         },
         {
+          "label": "Label for the argument",
+          "default": "Argument"
+        },
+        {
           "label": "Texto adentro de la zona de caída de los argumentos cuando está deshabilitado el añadir nuevos argumentos",
           "default": "Dejar caer argumentos aquí"
         }

--- a/language/es.json
+++ b/language/es.json
@@ -112,6 +112,10 @@
           "default": "Eliminar argumento"
         },
         {
+          "label": "Label used to show the edit action",
+          "default": "Edit argument"
+        },
+        {
           "label": "Texto adentro de la zona de caída de los argumentos cuando está deshabilitado el añadir nuevos argumentos",
           "default": "Dejar caer argumentos aquí"
         }

--- a/language/eu.json
+++ b/language/eu.json
@@ -112,6 +112,10 @@
           "default": "Ezabatu argudioa"
         },
         {
+          "label": "Label used to show the edit action",
+          "default": "Edit argument"
+        },
+        {
           "label": "Argudioak jaregiteko eremuan dagoen testua ezin denean argudio berriak gehitu",
           "default": "Jaregin argudioak hona"
         }

--- a/language/eu.json
+++ b/language/eu.json
@@ -116,6 +116,10 @@
           "default": "Edit argument"
         },
         {
+          "label": "Label for the argument",
+          "default": "Argument"
+        },
+        {
           "label": "Argudioak jaregiteko eremuan dagoen testua ezin denean argudio berriak gehitu",
           "default": "Jaregin argudioak hona"
         }

--- a/language/fr.json
+++ b/language/fr.json
@@ -116,6 +116,10 @@
           "default": "Edit argument"
         },
         {
+          "label": "Label for the argument",
+          "default": "Argument"
+        },
+        {
           "label": "Texte à l'intérieur de la zone de dépôt des arguments lorsque l'ajout de nouveaux arguments est inactivé",
           "default": "Déposer les arguments ici"
         }

--- a/language/fr.json
+++ b/language/fr.json
@@ -112,6 +112,10 @@
           "default": "Supprimer l’argument"
         },
         {
+          "label": "Label used to show the edit action",
+          "default": "Edit argument"
+        },
+        {
           "label": "Texte à l'intérieur de la zone de dépôt des arguments lorsque l'ajout de nouveaux arguments est inactivé",
           "default": "Déposer les arguments ici"
         }

--- a/language/gl.json
+++ b/language/gl.json
@@ -116,6 +116,10 @@
           "default": "Edit argument"
         },
         {
+          "label": "Label for the argument",
+          "default": "Argument"
+        },
+        {
           "label": "Texto na zona de solta de argumentos cando a adición de argumentos está desactivada",
           "default": "Solta aquí os teus argumentos"
         }

--- a/language/gl.json
+++ b/language/gl.json
@@ -112,6 +112,10 @@
           "default": "Borrar argumento"
         },
         {
+          "label": "Label used to show the edit action",
+          "default": "Edit argument"
+        },
+        {
           "label": "Texto na zona de solta de argumentos cando a adición de argumentos está desactivada",
           "default": "Solta aquí os teus argumentos"
         }

--- a/language/lt.json
+++ b/language/lt.json
@@ -112,6 +112,10 @@
           "default": "Ištrinti argumentą"
         },
         {
+          "label": "Label used to show the edit action",
+          "default": "Edit argument"
+        },
+        {
           "label": "Text inside the arguments drop zone",
           "default": "Mesti argumentus čia"
         }

--- a/language/lt.json
+++ b/language/lt.json
@@ -116,6 +116,10 @@
           "default": "Edit argument"
         },
         {
+          "label": "Label for the argument",
+          "default": "Argument"
+        },
+        {
           "label": "Text inside the arguments drop zone",
           "default": "Mesti argumentus čia"
         }

--- a/language/nb.json
+++ b/language/nb.json
@@ -112,6 +112,10 @@
           "default": "Slett argument"
         },
         {
+          "label": "Tekst som brukes for å vise 'rediger' muligheten",
+          "default": "Rediger argument"
+        },
+        {
           "label": "Tekst som vises inne i slippsonen for argumenter",
           "default": "Slipp argumenter her"
         }

--- a/language/nb.json
+++ b/language/nb.json
@@ -116,6 +116,10 @@
           "default": "Rediger argument"
         },
         {
+          "label": "Tekst for argumentet",
+          "default": "Argument"
+        },
+        {
           "label": "Tekst som vises inne i slippsonen for argumenter",
           "default": "Slipp argumenter her"
         }

--- a/language/nn.json
+++ b/language/nn.json
@@ -112,6 +112,10 @@
           "default": "Slett argument"
         },
         {
+          "label": "Tekst som brukes for å indikere 'Rediger argument' muligheten",
+          "default": "Rediger argument"
+        },
+        {
           "label": "Tekst som vises inne i slippsonen for argumenter",
           "default": "Slipp argumenter her"
         }

--- a/language/nn.json
+++ b/language/nn.json
@@ -116,6 +116,10 @@
           "default": "Rediger argument"
         },
         {
+          "label": "Tekst for argumentet",
+          "default": "Argument"
+        },
+        {
           "label": "Tekst som vises inne i slippsonen for argumenter",
           "default": "Slipp argumenter her"
         }

--- a/language/pt.json
+++ b/language/pt.json
@@ -116,6 +116,10 @@
           "default": "Edit argument"
         },
         {
+          "label": "Label for the argument",
+          "default": "Argument"
+        },
+        {
           "label": "A funcionalidade de inserção de texto dentro da zona para arrastar e largar argumentos ao adicionar novos argumentos está desactivada",
           "default": "Largue os argumentos aqui"
         }

--- a/language/pt.json
+++ b/language/pt.json
@@ -112,6 +112,10 @@
           "default": "Eliminar argumento"
         },
         {
+          "label": "Label used to show the edit action",
+          "default": "Edit argument"
+        },
+        {
           "label": "A funcionalidade de inserção de texto dentro da zona para arrastar e largar argumentos ao adicionar novos argumentos está desactivada",
           "default": "Largue os argumentos aqui"
         }

--- a/language/sw.json
+++ b/language/sw.json
@@ -112,6 +112,10 @@
           "default": "Futa hoja"
         },
         {
+          "label": "Label used to show the edit action",
+          "default": "Edit argument"
+        },
+        {
           "label": "Maandishi ndani ya eneo la kushuka la hoja wakati wa kuongeza hoja mpya yamezimwa",
           "default": "Acha hoja hapa"
         }

--- a/language/sw.json
+++ b/language/sw.json
@@ -116,6 +116,10 @@
           "default": "Edit argument"
         },
         {
+          "label": "Label for the argument",
+          "default": "Argument"
+        },
+        {
           "label": "Maandishi ndani ya eneo la kushuka la hoja wakati wa kuongeza hoja mpya yamezimwa",
           "default": "Acha hoja hapa"
         }

--- a/semantics.json
+++ b/semantics.json
@@ -216,6 +216,12 @@
         "default": "Edit argument"
       },
       {
+        "name": "argument",
+        "type": "text",
+        "label": "Label for the argument",
+        "default": "Argument"
+      },
+      {
         "name": "dropArgumentsHere",
         "type": "text",
         "label": "Text inside the arguments drop zone",

--- a/semantics.json
+++ b/semantics.json
@@ -210,6 +210,12 @@
         "default": "Delete argument"
       },
       {
+        "name": "editArgument",
+        "type": "text",
+        "label": "Label used to show the edit action",
+        "default": "Edit argument"
+      },
+      {
         "name": "dropArgumentsHere",
         "type": "text",
         "label": "Text inside the arguments drop zone",

--- a/src/app.js
+++ b/src/app.js
@@ -62,6 +62,7 @@ H5P.Discussion = (function () {
       moveTo: 'Move to',
       deleteArgument: 'Delete argument',
       editArgument: 'Edit argument',
+      argument: 'Argument',
       actionMenuTitle: 'Action menu',
       actionMenuDescription: 'Select the action you want to perform on this argument',
       dropArgumentsHere: 'Drop arguments here',

--- a/src/app.js
+++ b/src/app.js
@@ -61,6 +61,7 @@ H5P.Discussion = (function () {
       argumentsAgainst: 'Arguments AGAINST',
       moveTo: 'Move to',
       deleteArgument: 'Delete argument',
+      editArgument: 'Edit argument',
       actionMenuTitle: 'Action menu',
       actionMenuDescription: 'Select the action you want to perform on this argument',
       dropArgumentsHere: 'Drop arguments here',

--- a/src/components/Argument/Argument.js
+++ b/src/components/Argument/Argument.js
@@ -7,19 +7,18 @@ import classnames from 'classnames';
 import DragArrows from './components/DragArrows';
 import {getDnDId} from '../utils';
 
-function Argument(props) {
-
+function Argument({
+  argument,
+  onArgumentChange,
+  startEditing,
+  stopEditing,
+  enableEditing = false,
+  isDragging = false,
+  isDragEnabled = true,
+  actions,
+}) {
   const innerRef = useRef(null);
   const [refReady, setRef] = useState(false);
-
-  const {
-    argument,
-    onArgumentChange,
-    enableEditing = false,
-    isDragging = false,
-    isDragEnabled = true,
-    actions,
-  } = props;
 
   const [showPopover, togglePopover] = useState(false);
 
@@ -43,17 +42,15 @@ function Argument(props) {
       <EditableArgument
         argument={argument.argumentText}
         inEditMode={argument.editMode}
-        onBlur={onArgumentChange}
+        onChange={onArgumentChange}
+        startEditing={startEditing}
+        stopEditing={stopEditing}
         idBase={argument.id}
       />
     );
   }
   else {
-    displayStatement = (
-      <UnEditableArgument
-        argument={argument.argumentText}
-      />
-    );
+    displayStatement = <UnEditableArgument argument={argument.argumentText} />;
   }
 
   let argumentLayout = (
@@ -82,10 +79,7 @@ function Argument(props) {
   }
 
   return (
-    <div
-      id={getDnDId(argument)}
-      ref={innerRef}
-    >
+    <div id={getDnDId(argument)} ref={innerRef}>
       {argumentLayout}
     </div>
   );
@@ -94,6 +88,8 @@ function Argument(props) {
 Argument.propTypes = {
   argument: PropTypes.object,
   onArgumentChange: PropTypes.func,
+  startEditing: PropTypes.func,
+  stopEditing: PropTypes.func,
   enableEditing: PropTypes.bool,
   onArgumentDelete: PropTypes.func,
   isDragging: PropTypes.bool,
@@ -101,29 +97,22 @@ Argument.propTypes = {
   actions: PropTypes.array,
 };
 
-function ArgumentLayout(props) {
-
-  const {
-    activeDraggable,
-    isDragEnabled,
-    statementDisplay,
-    showPopover,
-    menuId,
-    toggle,
-  } = props;
-
+function ArgumentLayout({
+  activeDraggable,
+  isDragEnabled,
+  statementDisplay,
+  showPopover,
+  menuId,
+  toggle,
+}) {
   return (
-    <div
-      className={'h5p-discussion-argument-container'}
-    >
+    <div className={'h5p-discussion-argument-container'}>
       <div
         className={classnames('h5p-discussion-argument', {
           'h5p-discussion-active-draggable': activeDraggable
         })}
       >
-        <div
-          className={'h5p-discussion-argument-provided'}
-        >
+        <div className={'h5p-discussion-argument-provided'}>
           {isDragEnabled && (
             <DragArrows/>
           )}
@@ -132,7 +121,7 @@ function ArgumentLayout(props) {
             className={'h5p-discussion-argument-actions'}
             aria-label={'See available actions'}
             aria-expanded={showPopover}
-            aria-controls={menuId}
+            aria-controls={showPopover ? menuId : undefined}
             onClick={toggle}
             type={'button'}
           >
@@ -153,13 +142,9 @@ ArgumentLayout.propTypes = {
 };
 
 ArgumentLayout.defaultProps = {
-  toggle: () => {
-  },
+  toggle: () => {},
   isDragEnabled: true,
   activeDraggable: false,
 };
 
-export {
-  Argument as default,
-  ArgumentLayout
-};
+export { Argument as default, ArgumentLayout };

--- a/src/components/Argument/components/ActionMenu.js
+++ b/src/components/Argument/components/ActionMenu.js
@@ -108,15 +108,15 @@ function ActionMenu(props) {
     return (
       <button
         className={'h5p-discussion-popover-actionmenu-delete'}
-        aria-label={settings.title}
         type={'button'}
         onClick={(e) => {
           e.preventDefault();
           settings.onSelect();
         }}
       >
-        <span
-          className={'h5p-discussion-popover-actionmenu-labeltext'}>{settings.title}
+        <span className={'h5p-ri h5p-discussion-popover-actionmenu-delete-icon'} aria-hidden={true} />
+        <span className={'h5p-discussion-popover-actionmenu-labeltext'}>
+          {settings.title}
         </span>
       </button>
     );
@@ -126,15 +126,15 @@ function ActionMenu(props) {
     return (
       <button
         className={'h5p-discussion-popover-actionmenu-edit'}
-        aria-label={settings.title}
         type={'button'}
         onClick={(e) => {
           e.preventDefault();
           handleSelect(settings.onSelect);
         }}
       >
-        <span
-          className={'h5p-discussion-popover-actionmenu-labeltext'}>{settings.title}
+        <span className={'h5p-ri hri-pencil'} aria-hidden={true} />
+        <span className={'h5p-discussion-popover-actionmenu-labeltext'}>
+          {settings.title}
         </span>
       </button>
     );

--- a/src/components/Argument/components/ActionMenu.js
+++ b/src/components/Argument/components/ActionMenu.js
@@ -122,6 +122,24 @@ function ActionMenu(props) {
     );
   }
 
+  function getEdit(settings) {
+    return (
+      <button
+        className={'h5p-discussion-popover-actionmenu-edit'}
+        aria-label={settings.title}
+        type={'button'}
+        onClick={(e) => {
+          e.preventDefault();
+          handleSelect(settings.onSelect);
+        }}
+      >
+        <span
+          className={'h5p-discussion-popover-actionmenu-labeltext'}>{settings.title}
+        </span>
+      </button>
+    );
+  }
+
   return (
     <TinyPopover
       containerClassName={classNames.join(' ')}
@@ -151,6 +169,9 @@ function ActionMenu(props) {
               let content;
               if (action.type === 'delete') {
                 content = getDelete(action, index);
+              }
+              else if (action.type === 'edit') {
+                content = getEdit(action, index);
               }
               else {
                 content = getCategory(action, index);

--- a/src/components/Argument/components/EditableArgument.js
+++ b/src/components/Argument/components/EditableArgument.js
@@ -1,31 +1,27 @@
-import React, {useState, useRef, useEffect} from 'react';
+import React, {useRef, useEffect} from 'react';
 import PropsTypes from 'prop-types';
 import classnames from 'classnames';
 import {debounce} from '../../utils';
+import {useDiscussionContext} from '../../../context/DiscussionContext';
 
-function EditableArgument(props) {
-
-  const [inEditMode, toggleEditMode] = useState(props.inEditMode);
+function EditableArgument({
+  argument,
+  inEditMode,
+  onChange,
+  startEditing,
+  stopEditing,
+  idBase,
+}) {
+  const { translate } = useDiscussionContext();
 
   const inputRef = useRef();
 
   useEffect(() => {
     if (inEditMode === true) {
+      inputRef.current.value = argument;
       inputRef.current.focus();
     }
-  }, []);
-
-  const handleClick = () => {
-    if (inEditMode === false) {
-      toggleEditMode(true);
-      inputRef.current.value = props.argument;
-      setTimeout(() => inputRef.current.focus(), 0);
-    }
-  };
-
-  const handleBlur = () => {
-    toggleEditMode(false);
-  };
+  }, [inEditMode]);
 
   /**
    * Handle keydown events.
@@ -33,18 +29,17 @@ function EditableArgument(props) {
    * when arguments are added with the enter key.
    */
   const handleKeyDown = (event) => {
-    // If enter key is pressed
     if (event.key === 'Enter') {
       if (inEditMode) {
-        handleBlur();
+        stopEditing();
       }
       else {
-        handleClick();
+        startEditing();
       }
     }
   };
 
-  const id = 'es_' + props.idBase;
+  const id = 'es_' + idBase;
   const labelId = 'label_' + id;
   const inputId = 'input_' + id;
 
@@ -58,14 +53,14 @@ function EditableArgument(props) {
     <div
       role={'textbox'}
       tabIndex={0}
-      onClick={handleClick}
+      onClick={startEditing}
       className={'h5p-discussion-editable-container'}
       onKeyDown={handleKeyDown}
       aria-labelledby={labelId}
     >
       <div>
         <label
-          title={props.argument}
+          title={argument}
           htmlFor={inputId}
           id={labelId}
           className={classnames('h5p-discussion-editable', {
@@ -76,9 +71,9 @@ function EditableArgument(props) {
           <input
             className={'h5p-discussion-editable'}
             ref={inputRef}
-            onBlur={handleBlur}
-            onChange={debounce(() => props.onBlur(inputRef.current.value), 200)}
-            aria-label={'Edit argument ' + props.argument}
+            onBlur={stopEditing}
+            onChange={debounce(() => onChange(inputRef.current.value), 200)}
+            aria-label={`${translate('editArgument')} ${argument}`}
             id={inputId}
           />
         </label>
@@ -87,7 +82,7 @@ function EditableArgument(props) {
             'hidden': inEditMode === true,
           })}
         >
-          {props.argument}
+          {argument}
         </p>
       </div>
     </div>
@@ -97,7 +92,9 @@ function EditableArgument(props) {
 EditableArgument.propTypes = {
   argument: PropsTypes.string,
   inEditMode: PropsTypes.bool,
-  onBlur: PropsTypes.func,
+  onChange: PropsTypes.func,
+  startEditing: PropsTypes.func,
+  stopEditing: PropsTypes.func,
   idBase: PropsTypes.oneOfType([
     PropsTypes.string,
     PropsTypes.number,

--- a/src/components/Argument/components/EditableArgument.js
+++ b/src/components/Argument/components/EditableArgument.js
@@ -67,7 +67,7 @@ function EditableArgument({
             'hidden': inEditMode === false,
           })}
         >
-          <span className={'visible-hidden'}>Argument</span>
+          <span className={'visible-hidden'}>{translate('argument')}</span>
           <input
             className={'h5p-discussion-editable'}
             ref={inputRef}

--- a/src/components/Discussion.scss
+++ b/src/components/Discussion.scss
@@ -614,7 +614,8 @@ article, aside, details, figcaption, figure, footer, header, main, menu, nav, se
   flex: auto;
 
   label,
-  .h5p-discussion-popover-actionmenu-delete {
+  .h5p-discussion-popover-actionmenu-delete,
+  .h5p-discussion-popover-actionmenu-edit {
     padding: 1rem 0.9rem;
     display: flex;
     overflow: hidden;
@@ -628,6 +629,16 @@ article, aside, details, figcaption, figure, footer, header, main, menu, nav, se
   .h5p-discussion-popover-actionmenu-delete {
     &::before {
       content: "\f014";
+      font-family: "H5PFontAwesome4", sans-serif;
+      font-size: 1.25em;
+      left: 0.9em;
+      position: absolute;
+    }
+  }
+
+  .h5p-discussion-popover-actionmenu-edit {
+    &::before {
+      content: "\f040";
       font-family: "H5PFontAwesome4", sans-serif;
       font-size: 1.25em;
       left: 0.9em;
@@ -667,7 +678,8 @@ article, aside, details, figcaption, figure, footer, header, main, menu, nav, se
     color: #121212;
   }
 
-  .h5p-discussion-popover-actionmenu-delete .h5p-discussion-popover-actionmenu-labeltext {
+  .h5p-discussion-popover-actionmenu-delete .h5p-discussion-popover-actionmenu-labeltext,
+  .h5p-discussion-popover-actionmenu-edit .h5p-discussion-popover-actionmenu-labeltext {
     color: #1a1616;
     margin-left: 1.75em;
   }

--- a/src/components/Discussion.scss
+++ b/src/components/Discussion.scss
@@ -616,6 +616,7 @@ article, aside, details, figcaption, figure, footer, header, main, menu, nav, se
   label,
   .h5p-discussion-popover-actionmenu-delete,
   .h5p-discussion-popover-actionmenu-edit {
+    color: #1a1616;
     padding: 1rem 0.9rem;
     display: flex;
     overflow: hidden;

--- a/src/components/Discussion.scss
+++ b/src/components/Discussion.scss
@@ -627,23 +627,11 @@ article, aside, details, figcaption, figure, footer, header, main, menu, nav, se
     }
   }
 
-  .h5p-discussion-popover-actionmenu-delete {
+  .h5p-discussion-popover-actionmenu-delete-icon {
     &::before {
       content: "\f014";
       font-family: "H5PFontAwesome4", sans-serif;
       font-size: 1.25em;
-      left: 0.9em;
-      position: absolute;
-    }
-  }
-
-  .h5p-discussion-popover-actionmenu-edit {
-    &::before {
-      content: "\f040";
-      font-family: "H5PFontAwesome4", sans-serif;
-      font-size: 1.25em;
-      left: 0.9em;
-      position: absolute;
     }
   }
 
@@ -682,7 +670,6 @@ article, aside, details, figcaption, figure, footer, header, main, menu, nav, se
   .h5p-discussion-popover-actionmenu-delete .h5p-discussion-popover-actionmenu-labeltext,
   .h5p-discussion-popover-actionmenu-edit .h5p-discussion-popover-actionmenu-labeltext {
     color: #1a1616;
-    margin-left: 1.75em;
   }
 }
 

--- a/src/components/Surface/Surface.js
+++ b/src/components/Surface/Surface.js
@@ -289,6 +289,15 @@ function Surface() {
       }));
     if ( allowAddingOfArguments === true ) {
       dynamicActions.push(new ActionMenuDataObject({
+        type: 'edit',
+        title: 'Edit argument',
+        onSelect: () => {
+          const argumentElement = document.getElementById(getDnDId(argument));
+          const textbox = argumentElement?.querySelector('.h5p-discussion-editable-container');
+          textbox?.click();
+        }
+      }));
+      dynamicActions.push(new ActionMenuDataObject({
         type: 'delete',
         title: translate('deleteArgument'),
         onSelect: () => dispatch({

--- a/src/components/Surface/Surface.js
+++ b/src/components/Surface/Surface.js
@@ -290,7 +290,7 @@ function Surface() {
     if ( allowAddingOfArguments === true ) {
       dynamicActions.push(new ActionMenuDataObject({
         type: 'edit',
-        title: 'Edit argument',
+        title: translate('editArgument'),
         onSelect: () => {
           const argumentElement = document.getElementById(getDnDId(argument));
           const textbox = argumentElement?.querySelector('.h5p-discussion-editable-container');

--- a/src/components/Surface/Surface.js
+++ b/src/components/Surface/Surface.js
@@ -102,6 +102,26 @@ function Surface() {
           actionDropActive: false,
         };
       }
+      case 'setEditMode': {
+        const {
+          id,
+          editMode,
+        } = action.payload;
+        const newArguments = state.argumentsList.map((argument) => {
+          if (argument.id === id) {
+            return {
+              ...argument,
+              editMode: editMode,
+            };
+          }
+          return argument;
+        });
+
+        return {
+          ...state,
+          argumentsList: newArguments
+        };
+      }
       case 'editArgument': {
         const {
           id,
@@ -112,7 +132,6 @@ function Surface() {
         if (argumentIndex !== -1) {
           const argument = newArguments[argumentIndex];
           argument.argumentText = argumentText;
-          argument.editMode = false;
         }
         return {
           ...state,
@@ -291,11 +310,10 @@ function Surface() {
       dynamicActions.push(new ActionMenuDataObject({
         type: 'edit',
         title: translate('editArgument'),
-        onSelect: () => {
-          const argumentElement = document.getElementById(getDnDId(argument));
-          const textbox = argumentElement?.querySelector('.h5p-discussion-editable-container');
-          textbox?.click();
-        }
+        onSelect: () => dispatch({
+          type: 'setEditMode',
+          payload: {id: argument.id, editMode: true}
+        })
       }));
       dynamicActions.push(new ActionMenuDataObject({
         type: 'delete',
@@ -354,6 +372,15 @@ function Surface() {
                             type: 'editArgument',
                             payload: {id: argument.id, argumentText}
                           })}
+                          startEditing={() => dispatch({
+                            type: 'setEditMode',
+                            payload: {id: argument.id, editMode: true}
+                          })}
+                          stopEditing={() => dispatch({
+                            type: 'setEditMode',
+                            payload: {id: argument.id, editMode: false}
+                          })
+                          }
                         />
                       </Element>
                     ))}
@@ -413,6 +440,14 @@ function Surface() {
                         onArgumentChange={(argumentText) => dispatch({
                           type: 'editArgument',
                           payload: {id: argument.id, argumentText}
+                        })}
+                        startEditing={() => dispatch({
+                          type: 'setEditMode',
+                          payload: {id: argument.id, editMode: true}
+                        })}
+                        stopEditing={() => dispatch({
+                          type: 'setEditMode',
+                          payload: {id: argument.id, editMode: false}
                         })}
                       />
                     </Element>


### PR DESCRIPTION
Adds a new action in the action menu of the arguments called "Edit argument" that will activate editing of the argument.  This action will be visible when users can add their own arguments. 


Screenshot:
<img width="336" alt="Discussion_edit-argument" src="https://github.com/NDLANO/h5p-discussion/assets/35261194/a3ba57d7-a106-49cd-adcd-1732e7dfdade">